### PR TITLE
WIP: LLVM 14.0.6

### DIFF
--- a/rpm/0001-LLVM-Add-MeeGo-vendor-type.patch
+++ b/rpm/0001-LLVM-Add-MeeGo-vendor-type.patch
@@ -1,8 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ruben De Smet <ruben.de.smet@rubdos.be>
+Date: Sun, 26 Jun 2022 10:48:13 +0200
+Subject: [PATCH] LLVM: Add MeeGo vendor type
+
+---
+ llvm/include/llvm/ADT/Triple.h    |  3 ++-
+ llvm/lib/Support/Triple.cpp       | 12 ++++++++++++
+ llvm/unittests/ADT/TripleTest.cpp |  6 ++++++
+ 3 files changed, 20 insertions(+), 1 deletion(-)
+
 diff --git a/llvm/include/llvm/ADT/Triple.h b/llvm/include/llvm/ADT/Triple.h
-index 76a754d671f..6ee7f680dee 100644
+index 42277c013035954dfe6e4c9359dc9ccc68b7d8cd..9e36dfd4d2d570cdaf54d9c07aa60b05d4ab8476 100644
 --- a/llvm/include/llvm/ADT/Triple.h
 +++ b/llvm/include/llvm/ADT/Triple.h
-@@ -152,7 +152,8 @@ public:
+@@ -165,7 +165,8 @@ public:
      Mesa,
      SUSE,
      OpenEmbedded,
@@ -13,10 +24,10 @@ index 76a754d671f..6ee7f680dee 100644
    enum OSType {
      UnknownOS,
 diff --git a/llvm/lib/Support/Triple.cpp b/llvm/lib/Support/Triple.cpp
-index 2c480c1094a..e7d399bfa4f 100644
+index a9afcc9db96ab5910c7c739557fd1c1aa2d5a8cd..c4307bf457c7cf944eec330364f5b3a752b1857f 100644
 --- a/llvm/lib/Support/Triple.cpp
 +++ b/llvm/lib/Support/Triple.cpp
-@@ -162,6 +162,7 @@ StringRef Triple::getVendorTypeName(VendorType Kind) {
+@@ -177,6 +177,7 @@ StringRef Triple::getVendorTypeName(VendorType Kind) {
    case Freescale: return "fsl";
    case IBM: return "ibm";
    case ImaginationTechnologies: return "img";
@@ -24,7 +35,7 @@ index 2c480c1094a..e7d399bfa4f 100644
    case Mesa: return "mesa";
    case MipsTechnologies: return "mti";
    case Myriad: return "myriad";
-@@ -479,6 +480,7 @@ static Triple::VendorType parseVendor(StringRef VendorName) {
+@@ -507,6 +508,7 @@ static Triple::VendorType parseVendor(StringRef VendorName) {
      .Case("mesa", Triple::Mesa)
      .Case("suse", Triple::SUSE)
      .Case("oe", Triple::OpenEmbedded)
@@ -32,7 +43,7 @@ index 2c480c1094a..e7d399bfa4f 100644
      .Default(Triple::UnknownVendor);
  }
  
-@@ -743,6 +745,9 @@ Triple::Triple(const Twine &Str)
+@@ -802,6 +804,9 @@ Triple::Triple(const Twine &Str)
          OS = parseOS(Components[2]);
          if (Components.size() > 3) {
            Environment = parseEnvironment(Components[3]);
@@ -42,7 +53,7 @@ index 2c480c1094a..e7d399bfa4f 100644
            ObjectFormat = parseFormat(Components[3]);
          }
        }
-@@ -794,6 +799,10 @@ Triple::Triple(const Twine &ArchStr, const Twine &VendorStr, const Twine &OSStr,
+@@ -853,6 +858,10 @@ Triple::Triple(const Twine &ArchStr, const Twine &VendorStr, const Twine &OSStr,
        ObjectFormat(parseFormat(EnvironmentStr.str())) {
    if (ObjectFormat == Triple::UnknownObjectFormat)
      ObjectFormat = getDefaultFormat(*this);
@@ -53,8 +64,8 @@ index 2c480c1094a..e7d399bfa4f 100644
  }
  
  std::string Triple::normalize(StringRef Str) {
-@@ -1056,6 +1065,9 @@ void Triple::getEnvironmentVersion(unsigned &Major, unsigned &Minor,
-                                    unsigned &Micro) const {
+@@ -1103,6 +1112,9 @@ static VersionTuple parseVersionFromName(StringRef Name) {
+ VersionTuple Triple::getEnvironmentVersion() const {
    StringRef EnvironmentName = getEnvironmentName();
    StringRef EnvironmentTypeName = getEnvironmentTypeName(getEnvironment());
 +  // MeeGo uses "gnueabi" to mean "gnueabihf"
@@ -64,10 +75,10 @@ index 2c480c1094a..e7d399bfa4f 100644
      EnvironmentName = EnvironmentName.substr(EnvironmentTypeName.size());
  
 diff --git a/llvm/unittests/ADT/TripleTest.cpp b/llvm/unittests/ADT/TripleTest.cpp
-index ef7f82d268e..5f9c04832ec 100644
+index 3006ab6d40e85e3fda02d163954a93262191cd68..7a28ed624232ee0c195ffa41c927c02cb8dd28e3 100644
 --- a/llvm/unittests/ADT/TripleTest.cpp
 +++ b/llvm/unittests/ADT/TripleTest.cpp
-@@ -355,6 +355,12 @@ TEST(TripleTest, ParsedIDs) {
+@@ -384,6 +384,12 @@ TEST(TripleTest, ParsedIDs) {
    EXPECT_EQ(Triple::Linux, T.getOS());
    EXPECT_EQ(Triple::GNUEABI, T.getEnvironment());
  

--- a/rpm/0002-Add-Triple-isMeeGo.patch
+++ b/rpm/0002-Add-Triple-isMeeGo.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ruben De Smet <ruben.de.smet@rubdos.be>
+Date: Sun, 26 Jun 2022 10:41:44 +0200
+Subject: [PATCH] Add Triple::isMeeGo()
+
+---
+ llvm/include/llvm/ADT/Triple.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/llvm/include/llvm/ADT/Triple.h b/llvm/include/llvm/ADT/Triple.h
+index 9e36dfd4d2d570cdaf54d9c07aa60b05d4ab8476..8e66888615ffa21d641322e4bfacbf58cd23b283 100644
+--- a/llvm/include/llvm/ADT/Triple.h
++++ b/llvm/include/llvm/ADT/Triple.h
+@@ -657,6 +657,9 @@ public:
+   /// Tests whether the target is Android
+   bool isAndroid() const { return getEnvironment() == Triple::Android; }
+ 
++  /// Tests whether the target is Android
++  bool isMeeGo() const { return getVendor() == Triple::MeeGo; }
++
+   bool isAndroidVersionLT(unsigned Major) const {
+     assert(isAndroid() && "Not an Android triple!");
+ 

--- a/rpm/0003-Clang-SailfishOS-toolchain.patch
+++ b/rpm/0003-Clang-SailfishOS-toolchain.patch
@@ -1,8 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ruben De Smet <ruben.de.smet@rubdos.be>
+Date: Sun, 26 Jun 2022 10:57:51 +0200
+Subject: [PATCH] Clang: SailfishOS toolchain
+
+Signed-off-by: Ruben De Smet <ruben.de.smet@rubdos.be>
+---
+ clang/include/clang/Driver/Distro.h   | 5 +++++
+ clang/lib/Driver/Distro.cpp           | 3 +++
+ clang/lib/Driver/ToolChains/Gnu.cpp   | 4 +++-
+ clang/lib/Driver/ToolChains/Linux.cpp | 8 ++++----
+ 4 files changed, 15 insertions(+), 5 deletions(-)
+
 diff --git a/clang/include/clang/Driver/Distro.h b/clang/include/clang/Driver/Distro.h
-index d382cf77a8b..8c06919f1d3 100644
+index 2723f75e8945831fcd94c8c40660a4826f0e2102..58616ad541e1e50a9b6f8b338ba3ee106cd3a827 100644
 --- a/clang/include/clang/Driver/Distro.h
 +++ b/clang/include/clang/Driver/Distro.h
-@@ -42,6 +42,7 @@ public:
+@@ -45,6 +45,7 @@ public:
      Fedora,
      Gentoo,
      OpenSUSE,
@@ -10,8 +23,8 @@ index d382cf77a8b..8c06919f1d3 100644
      UbuntuHardy,
      UbuntuIntrepid,
      UbuntuJaunty,
-@@ -119,6 +120,10 @@ public:
-     return DistroVal >= DebianLenny && DistroVal <= DebianBullseye;
+@@ -124,6 +125,10 @@ public:
+     return DistroVal >= DebianLenny && DistroVal <= DebianBookworm;
    }
  
 +  bool IsSailfish() const {
@@ -19,13 +32,13 @@ index d382cf77a8b..8c06919f1d3 100644
 +  }
 +
    bool IsUbuntu() const {
-     return DistroVal >= UbuntuHardy && DistroVal <= UbuntuFocal;
+     return DistroVal >= UbuntuHardy && DistroVal <= UbuntuJammy;
    }
 diff --git a/clang/lib/Driver/Distro.cpp b/clang/lib/Driver/Distro.cpp
-index 06707fefc9d..cf14a4073fd 100644
+index 5ac38c34d112884a9a07a0f4aadcb7a4086eb787..cccb2026e5277f284650ff5e31d0ab41a7edacd2 100644
 --- a/clang/lib/Driver/Distro.cpp
 +++ b/clang/lib/Driver/Distro.cpp
-@@ -163,6 +163,9 @@ static Distro::DistroType DetectDistro(llvm::vfs::FileSystem &VFS,
+@@ -197,6 +197,9 @@ static Distro::DistroType DetectDistro(llvm::vfs::FileSystem &VFS) {
    if (VFS.exists("/etc/gentoo-release"))
      return Distro::Gentoo;
  
@@ -36,40 +49,39 @@ index 06707fefc9d..cf14a4073fd 100644
  }
  
 diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
-index e8ef881e89a..1bad4f13226 100644
+index 7a9570a686f4bbaad8afb0597bc72b6cd8c9d60a..e7f57c8249615c65869f1b652da3a7d427f32808 100644
 --- a/clang/lib/Driver/ToolChains/Gnu.cpp
 +++ b/clang/lib/Driver/ToolChains/Gnu.cpp
-@@ -1999,7 +1999,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+@@ -2073,7 +2073,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
    static const char *const AArch64LibDirs[] = {"/lib64", "/lib"};
    static const char *const AArch64Triples[] = {
        "aarch64-none-linux-gnu", "aarch64-linux-gnu", "aarch64-redhat-linux",
--      "aarch64-suse-linux", "aarch64-linux-android"};
-+      "aarch64-suse-linux", "aarch64-linux-android", "aarch64-meego-linux-gnu"};
+-      "aarch64-suse-linux"};
++      "aarch64-suse-linux", "aarch64-meego-linux-gnu"};
    static const char *const AArch64beLibDirs[] = {"/lib"};
    static const char *const AArch64beTriples[] = {"aarch64_be-none-linux-gnu",
                                                   "aarch64_be-linux-gnu"};
-@@ -2009,6 +2009,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
-                                            "arm-linux-androideabi"};
+@@ -2082,6 +2082,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+   static const char *const ARMTriples[] = {"arm-linux-gnueabi"};
    static const char *const ARMHFTriples[] = {"arm-linux-gnueabihf",
                                               "armv7hl-redhat-linux-gnueabi",
 +                                             "armv7hl-meego-linux-gnueabi",
                                               "armv6hl-suse-linux-gnueabi",
                                               "armv7hl-suse-linux-gnueabi"};
    static const char *const ARMebLibDirs[] = {"/lib"};
-@@ -2036,7 +2037,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
-       "i586-redhat-linux",    "i386-redhat-linux",     "i586-suse-linux",
-       "i486-slackware-linux", "i686-montavista-linux", "i586-linux-gnu",
-       "i686-linux-android",   "i386-gnu",              "i486-gnu",
--      "i586-gnu",             "i686-gnu"};
-+      "i586-gnu",             "i686-gnu",              "i486-meego-linux"};
+@@ -2108,6 +2109,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+       "i586-linux-gnu",      "i686-linux-gnu",        "i686-pc-linux-gnu",
+       "i386-redhat-linux6E", "i686-redhat-linux",     "i386-redhat-linux",
+       "i586-suse-linux",     "i686-montavista-linux", "i686-gnu",
++      "i486-meego-linux"
+   };
  
-   static const char *const MIPSLibDirs[] = {"/lib"};
-   static const char *const MIPSTriples[] = {
+   static const char *const M68kLibDirs[] = {"/lib"};
 diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
-index 6532c899492..3fa0bea23bd 100644
+index 83cb41159de7ed36aad01e19ff62cc745df481a9..e7c2dcaef02aa2184307ea3db5e6257b7476b2f8 100644
 --- a/clang/lib/Driver/ToolChains/Linux.cpp
 +++ b/clang/lib/Driver/ToolChains/Linux.cpp
-@@ -248,7 +248,7 @@ Linux::Linux(const Driver &D, const llvm::Triple &Triple, const ArgList &Args)
+@@ -194,7 +194,7 @@ Linux::Linux(const Driver &D, const llvm::Triple &Triple, const ArgList &Args)
    }
  
    if (Distro.IsOpenSUSE() || Distro.IsUbuntu() || Distro.IsAlpineLinux() ||
@@ -78,7 +90,7 @@ index 6532c899492..3fa0bea23bd 100644
      ExtraOpts.push_back("-z");
      ExtraOpts.push_back("relro");
    }
-@@ -289,13 +289,13 @@ Linux::Linux(const Driver &D, const llvm::Triple &Triple, const ArgList &Args)
+@@ -233,13 +233,13 @@ Linux::Linux(const Driver &D, const llvm::Triple &Triple, const ArgList &Args)
    // Hexagon linker/loader does not support .gnu.hash
    if (!IsMips && !IsHexagon) {
      if (Distro.IsRedhat() || Distro.IsOpenSUSE() || Distro.IsAlpineLinux() ||
@@ -94,7 +106,7 @@ index 6532c899492..3fa0bea23bd 100644
          (IsAndroid && Triple.isAndroidVersionLT(23)))
        ExtraOpts.push_back("--hash-style=both");
    }
-@@ -304,7 +304,7 @@ Linux::Linux(const Driver &D, const llvm::Triple &Triple, const ArgList &Args)
+@@ -248,7 +248,7 @@ Linux::Linux(const Driver &D, const llvm::Triple &Triple, const ArgList &Args)
    ExtraOpts.push_back("--build-id");
  #endif
  

--- a/rpm/0004-Make-funwind-tables-the-default-for-all-archs.patch
+++ b/rpm/0004-Make-funwind-tables-the-default-for-all-archs.patch
@@ -1,18 +1,18 @@
-From 690373af5a5d50cf115ed6e4d2849bb786f9dc8e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: serge-sans-paille <sguelton@redhat.com>
 Date: Tue, 10 Dec 2019 09:18:03 +0000
 Subject: [PATCH] Make -funwind-tables the default for all archs
 
 ---
  clang/lib/Driver/ToolChain.cpp      | 2 +-
- clang/lib/Driver/ToolChains/Gnu.cpp | 2 +-
- 2 files changed, 2 insertions(+), 2 deletions(-)
+ clang/lib/Driver/ToolChains/Gnu.cpp | 3 +++
+ 2 files changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/clang/lib/Driver/ToolChain.cpp b/clang/lib/Driver/ToolChain.cpp
-index 18400d9def5..2643e9decc3 100644
+index d657d21bfcdb06b050778c2a75167a586b5ed7df..eac667382fa9b065ec7b82095147f7fbc05de633 100644
 --- a/clang/lib/Driver/ToolChain.cpp
 +++ b/clang/lib/Driver/ToolChain.cpp
-@@ -247,7 +247,7 @@ std::string ToolChain::getInputFilename(const InputInfo &Input) const {
+@@ -258,7 +258,7 @@ std::string ToolChain::getInputFilename(const InputInfo &Input) const {
  }
  
  bool ToolChain::IsUnwindTablesDefault(const ArgList &Args) const {
@@ -22,18 +22,16 @@ index 18400d9def5..2643e9decc3 100644
  
  Tool *ToolChain::getClang() const {
 diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
-index e8ef881e89a..088a21455ac 100644
+index e7f57c8249615c65869f1b652da3a7d427f32808..9c44b2e741ce69831f4a892b48eae8ee3073535d 100644
 --- a/clang/lib/Driver/ToolChains/Gnu.cpp
 +++ b/clang/lib/Driver/ToolChains/Gnu.cpp
-@@ -2610,7 +2610,7 @@ void Generic_GCC::printVerboseInfo(raw_ostream &OS) const {
+@@ -2692,6 +2692,9 @@ void Generic_GCC::printVerboseInfo(raw_ostream &OS) const {
  }
  
  bool Generic_GCC::IsUnwindTablesDefault(const ArgList &Args) const {
--  return getArch() == llvm::Triple::x86_64;
-+  return true;
- }
- 
- bool Generic_GCC::isPICDefault() const {
--- 
-2.20.1
-
++  if (getTriple().isMeeGo()) {
++    return true;
++  }
+   switch (getArch()) {
+   case llvm::Triple::aarch64:
+   case llvm::Triple::ppc:

--- a/rpm/0005-ToolChain-Add-lgcc_s-to-the-linker-flags-when-using-.patch
+++ b/rpm/0005-ToolChain-Add-lgcc_s-to-the-linker-flags-when-using-.patch
@@ -1,4 +1,4 @@
-From 09ae3ef5710a89505318ec721c65b6c838147276 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tom Stellard <tstellar@redhat.com>
 Date: Thu, 7 Feb 2019 21:05:37 -0800
 Subject: [PATCH] ToolChain: Add -lgcc_s to the linker flags when using libc++
@@ -12,10 +12,10 @@ provides this implementation.
  2 files changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/clang/lib/Driver/ToolChain.cpp b/clang/lib/Driver/ToolChain.cpp
-index 18400d9def5..3b455c26554 100644
+index eac667382fa9b065ec7b82095147f7fbc05de633..b83bd6d3ca5d630c4590bcb863c44d91626094ff 100644
 --- a/clang/lib/Driver/ToolChain.cpp
 +++ b/clang/lib/Driver/ToolChain.cpp
-@@ -895,6 +895,7 @@ void ToolChain::AddCXXStdlibLibArgs(const ArgList &Args,
+@@ -966,6 +966,7 @@ void ToolChain::AddCXXStdlibLibArgs(const ArgList &Args,
    switch (Type) {
    case ToolChain::CST_Libcxx:
      CmdArgs.push_back("-lc++");
@@ -24,7 +24,7 @@ index 18400d9def5..3b455c26554 100644
  
    case ToolChain::CST_Libstdcxx:
 diff --git a/clang/test/Driver/netbsd.cpp b/clang/test/Driver/netbsd.cpp
-index 4af7d8373d6..ff18c627f56 100644
+index 4af7d8373d67210aa121a933033e06c1d7f19075..ff18c627f560508504bf9f981c61cc6cbe0c839a 100644
 --- a/clang/test/Driver/netbsd.cpp
 +++ b/clang/test/Driver/netbsd.cpp
 @@ -131,7 +131,7 @@
@@ -45,6 +45,3 @@ index 4af7d8373d6..ff18c627f56 100644
  // S-ARM-7: "{{.*}}/usr/lib{{/|\\\\}}crtend.o" "{{.*}}/usr/lib{{/|\\\\}}crtn.o"
  
  // S-AARCH64: clang{{.*}}" "-cc1" "-triple" "aarch64-unknown-netbsd"
--- 
-1.8.3.1
-

--- a/rpm/0006-Disable-out-of-line-atomics-on-MeeGo.patch
+++ b/rpm/0006-Disable-out-of-line-atomics-on-MeeGo.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ruben De Smet <ruben.de.smet@rubdos.be>
+Date: Sun, 26 Jun 2022 10:42:13 +0200
+Subject: [PATCH] Disable out-of-line atomics on MeeGo
+
+---
+ clang/lib/Driver/ToolChains/Linux.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
+index e7c2dcaef02aa2184307ea3db5e6257b7476b2f8..9b377eca9dc8141620fd77b88eed9714806e160c 100644
+--- a/clang/lib/Driver/ToolChains/Linux.cpp
++++ b/clang/lib/Driver/ToolChains/Linux.cpp
+@@ -672,6 +672,8 @@ bool Linux::IsAArch64OutlineAtomicsDefault(const ArgList &Args) const {
+   // and libgcc since 9.3.1
+   assert(getTriple().isAArch64() && "expected AArch64 target!");
+   ToolChain::RuntimeLibType RtLib = GetRuntimeLibType(Args);
++  if (getTriple().isMeeGo())
++    return false;
+   if (RtLib == ToolChain::RLT_CompilerRT)
+     return true;
+   assert(RtLib == ToolChain::RLT_Libgcc && "unexpected runtime library type!");

--- a/rpm/clang.spec
+++ b/rpm/clang.spec
@@ -41,12 +41,12 @@ License:	NCSA
 URL:		http://llvm.org
 Source:		%{version}/%{name}-%{version}.tar.gz
 
-# LLVM patch
-Patch0:	llvm-sailfishos-toolchain.patch
-# clang patches
-Patch1:	0001-ToolChain-Add-lgcc_s-to-the-linker-flags-when-using-.patch
-Patch2:	0001-Make-funwind-tables-the-default-for-all-archs.patch
-Patch3:	clang-sailfishos-toolchain.patch
+Patch1: 0001-LLVM-Add-MeeGo-vendor-type.patch
+Patch2: 0002-Add-Triple-isMeeGo.patch
+Patch3: 0003-Clang-SailfishOS-toolchain.patch
+Patch4: 0004-Make-funwind-tables-the-default-for-all-archs.patch
+Patch5: 0005-ToolChain-Add-lgcc_s-to-the-linker-flags-when-using-.patch
+Patch6: 0006-Disable-out-of-line-atomics-on-MeeGo.patch
 
 BuildRequires:	gcc
 BuildRequires:	gcc-c++

--- a/rpm/clang.spec
+++ b/rpm/clang.spec
@@ -1,6 +1,6 @@
-%global maj_ver 10
+%global maj_ver 14
 %global min_ver 0
-%global patch_ver 1
+%global patch_ver 5
 
 %global clang_tools_binaries \
 	%{_bindir}/clang-apply-replacements \

--- a/rpm/llvm.spec
+++ b/rpm/llvm.spec
@@ -10,7 +10,7 @@
 %endif
 
 Name: llvm
-Version: 14.0.5
+Version: 14.0.6
 Release: 0
 Summary: The Low Level Virtual Machine (An Optimizing Compiler Infrastructure)
 License: University of Illinois/NCSA Open Source License

--- a/rpm/llvm.spec
+++ b/rpm/llvm.spec
@@ -16,12 +16,14 @@ Summary: The Low Level Virtual Machine (An Optimizing Compiler Infrastructure)
 License: University of Illinois/NCSA Open Source License
 URL: http://llvm.org/
 Source: %{version}/%{name}-%{version}.tar.gz
-# LLVM patch
-Patch0:	llvm-sailfishos-toolchain.patch
-# clang patches
-Patch1:	0001-ToolChain-Add-lgcc_s-to-the-linker-flags-when-using-.patch
-Patch2:	0001-Make-funwind-tables-the-default-for-all-archs.patch
-Patch3:	clang-sailfishos-toolchain.patch
+
+Patch1: 0001-LLVM-Add-MeeGo-vendor-type.patch
+Patch2: 0002-Add-Triple-isMeeGo.patch
+Patch3: 0003-Clang-SailfishOS-toolchain.patch
+Patch4: 0004-Make-funwind-tables-the-default-for-all-archs.patch
+Patch5: 0005-ToolChain-Add-lgcc_s-to-the-linker-flags-when-using-.patch
+Patch6: 0006-Disable-out-of-line-atomics-on-MeeGo.patch
+
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 BuildRequires: cmake, ninja

--- a/rpm/llvm.spec
+++ b/rpm/llvm.spec
@@ -10,7 +10,7 @@
 %endif
 
 Name: llvm
-Version: 10.0.1
+Version: 14.0.5
 Release: 0
 Summary: The Low Level Virtual Machine (An Optimizing Compiler Infrastructure)
 License: University of Illinois/NCSA Open Source License


### PR DESCRIPTION
LLVM 12+ is necessary for Rust 1.55+ https://github.com/sailfishos/rust/pull/15

Nothing has been tested yet here. Just putting out the code. This one was easy to get to compile.

TODO:
- [x] Compile Rust with it (trying this out as we speak)
- [x] Fix aarch64 build (libz.so is getting searched for in /usr/lib instead of /usr/lib64).
- [ ] Check whether Clang should also get bumped