### PR TITLE
LLVM 15.0.7

### DIFF
--- a/rpm/clang.spec
+++ b/rpm/clang.spec
@@ -1,6 +1,6 @@
-%global maj_ver 14
+%global maj_ver 15
 %global min_ver 0
-%global patch_ver 6
+%global patch_ver 7
 
 %global clang_tools_binaries \
 	%{_bindir}/clang-apply-replacements \
@@ -10,11 +10,13 @@
 	%{_bindir}/clang-extdef-mapping \
 	%{_bindir}/clang-format \
 	%{_bindir}/clang-include-fixer \
-	%{_bindir}/clang-move \
-	%{_bindir}/clang-offload-bundler \
-	%{_bindir}/clang-offload-wrapper \
 	%{_bindir}/clang-linker-wrapper \
+	%{_bindir}/clang-move \
 	%{_bindir}/clang-nvlink-wrapper \
+	%{_bindir}/clang-offload-bundler \
+	%{_bindir}/clang-offload-packager \
+	%{_bindir}/clang-offload-wrapper \
+	%{_bindir}/clang-pseudo \
 	%{_bindir}/clang-query \
 	%{_bindir}/clang-refactor \
 	%{_bindir}/clang-reorder-fields \

--- a/rpm/llvm.spec
+++ b/rpm/llvm.spec
@@ -10,7 +10,7 @@
 %endif
 
 Name: llvm
-Version: 14.0.6
+Version: 15.0.7
 Release: 0
 Summary: The Low Level Virtual Machine (An Optimizing Compiler Infrastructure)
 License: University of Illinois/NCSA Open Source License


### PR DESCRIPTION
This updates LLVM to the latest LLVM 15. LLVM 15 is the current minimum LLVM version for the current stable Rust release, and should not conflict with any current Jolla-compiled software. I am currently building this on a 4.5 platform SDK. i486 built fine, currently building armv7hl, and will test aarch64 thereafter.

I will submit separate patches for:

- The latest Rust compatible with the current Gecko that's shipped by SFOS
- The MSRV Rust compatible with the latest Gecko (if more recent than the above)
- The highest supported Rust compatible with the latest Gecko
- The latest stable Rust (which I will use for Whisperfish)
- The highest supported LLVMs for all of the above.

The intention is that Jolla may merge whichever and whenever they see fit, such that Whisperfish can lag ahead with Rust versions, while still contributing and staying ahead of the process with Rust updates.

Let's see how far I can get this.

Good resources:
- LLVM version update links: https://rustc-dev-guide.rust-lang.org/backend/updating-llvm.html

LLVM version map:
- Rust 1.64 -> LLVM <= 14
- Rust 1.65 -> LLVM <= 15
- Rust 1.70 -> LLVM <= 16 
- [Rust 1.75](https://github.com/sailfishos/rust/pull/22) -> <= LLVM 17 (source: https://github.com/rust-lang/rust/pull/118936, not yet in the updating docs)